### PR TITLE
fix: ApplicationError의 SESSION_NOT_FOUND 예외의 http code를 404에서 401로 변경

### DIFF
--- a/src/main/java/com/example/monghyang/domain/global/advice/ApplicationError.java
+++ b/src/main/java/com/example/monghyang/domain/global/advice/ApplicationError.java
@@ -30,7 +30,7 @@ public enum ApplicationError {
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "요청의 헤더에 refresh token이 존재하지 않습니다."),
     USER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "아이디와 비밀번호가 일치하지 않습니다."),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다. 다시 로그인 해주세요."),
-    SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "세션 정보가 존재하지 않습니다."),
+    SESSION_NOT_FOUND(HttpStatus.UNAUTHORIZED, "세션 정보가 존재하지 않습니다."),
     IMAGE_REQUEST_NULL(HttpStatus.BAD_REQUEST, "업로드할 이미지 파일이 null 입니다."),
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지가 존재하지 않습니다."),
     IMAGE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드 중 서버에서 에러가 발생했습니다."),


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

ApplicationError의 'SESSION_NOT_FOUND' 예외의 http code를 404에서 401로 변경하였습니다.
프론트엔드에서 http code 기반의 통합적인 예외처리를 위함입니다.

## 관련 이슈
<!---- 해당 PR과 관련된 이슈 번호가 있다면 작성해주세요. -->
<!---- Resolves: #(Isuue Number) -->

## PR 유형
<!-- 어떤 변경 사항이 있나요? -->

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
