### PR TITLE
[FIX] 상품 주문 처리 시 발생한 트랜잭션 문제 해결

### DIFF
--- a/src/main/java/com/example/monghyang/domain/orders/item/service/OrderItemFulFillmentHistoryService.java
+++ b/src/main/java/com/example/monghyang/domain/orders/item/service/OrderItemFulFillmentHistoryService.java
@@ -21,34 +21,34 @@ public class OrderItemFulFillmentHistoryService {
         this.orderItemFulfillmentHistoryRepository = orderItemFulfillmentHistoryRepository;
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void setFulfillmentCreated(OrderItem orderItem) {
         orderItemFulfillmentHistoryRepository.save(
                 OrderItemFulfillmentHistory.orderItemToStatusReasonCodeOf(orderItem, FulfillmentStatus.CREATED, "created"));
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void updateFulfillmentAllocated(OrderItem orderItem) {
         orderItem.updateFulfillmentStatus(FulfillmentStatus.ALLOCATED);
         orderItemFulfillmentHistoryRepository.save(OrderItemFulfillmentHistory.orderItemToStatusReasonCodeOf(orderItem, FulfillmentStatus.ALLOCATED, "allocated"));
     }
 
     // '배송 준비' 상태 설정
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void updateFulfillmentPacked(OrderItem orderItem) {
         orderItem.updateFulfillmentStatus(FulfillmentStatus.PACKED);
         orderItemFulfillmentHistoryRepository.save(
                 OrderItemFulfillmentHistory.orderItemToStatusReasonCodeOf(orderItem, FulfillmentStatus.PACKED, "packed"));
     }
     // '배송 중' 상태 설정
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void updateFulfillmentInTransit(OrderItem orderItem) {
         orderItem.updateFulfillmentStatus(FulfillmentStatus.IN_TRANSIT);
         orderItemFulfillmentHistoryRepository.save(
                 OrderItemFulfillmentHistory.orderItemToStatusReasonCodeOf(orderItem, FulfillmentStatus.IN_TRANSIT, "in-transit"));
     }
     // '배송 완료' 상태 설정
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void updateFulfillmentDelivered(OrderItem orderItem) {
         orderItem.updateFulfillmentStatus(FulfillmentStatus.DELIVERED);
         orderItemFulfillmentHistoryRepository.save(
@@ -60,7 +60,7 @@ public class OrderItemFulFillmentHistoryService {
      * @param orderItem 취소할 주문 요소
      * @param isProvider 취소를 수행하는 주체가 상품 게시자인지 나타내는 플래그
      */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void updateFulfillmentCanceled(OrderItem orderItem, boolean isProvider) {
         String message = (isProvider) ? "canceled by provider" : "canceled by user";
         orderItem.updateFulfillmentStatus(FulfillmentStatus.CANCELED);
@@ -70,7 +70,7 @@ public class OrderItemFulFillmentHistoryService {
 
 
     // '배송 실패' 상태 설정
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void updateFulfillmentFailed(OrderItem orderItem) {
         orderItem.updateFulfillmentStatus(FulfillmentStatus.FAILED);
         orderItemFulfillmentHistoryRepository.save(

--- a/src/main/java/com/example/monghyang/domain/orders/item/service/OrderItemRefundHistoryService.java
+++ b/src/main/java/com/example/monghyang/domain/orders/item/service/OrderItemRefundHistoryService.java
@@ -23,25 +23,25 @@ public class OrderItemRefundHistoryService {
         this.orderItemRefundHistoryRepository = repository;
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void setRefundNone(OrderItem orderItem) {
         orderItemRefundHistoryRepository.save(OrderItemRefundHistory.orderItemToStatusOf(orderItem, RefundStatus.NONE));
     }
 
     // '환불 요청' 상태 설정
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void updateRefundRequested(OrderItem orderItem) {
         orderItem.updateRefundStatus(RefundStatus.REQUESTED);
         orderItemRefundHistoryRepository.save(OrderItemRefundHistory.orderItemToStatusOf(orderItem, RefundStatus.REQUESTED));
     }
     // '반품 되었음' 상태 설정
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void updateRefundReturned(OrderItem orderItem) {
         orderItem.updateRefundStatus(RefundStatus.REQUESTED);
         orderItemRefundHistoryRepository.save(OrderItemRefundHistory.orderItemToStatusOf(orderItem, RefundStatus.RETURNED));
     }
     // '환불 처리됨' 상태 설정 및 환불 처리 로직
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void updateRefundRefunded(OrderItem orderItem) {
         /*
             PG사를 통해 해당 주문 요소 결제 금액에 해당하는 금액을 환불

--- a/src/main/java/com/example/monghyang/domain/product/service/ProductService.java
+++ b/src/main/java/com/example/monghyang/domain/product/service/ProductService.java
@@ -201,7 +201,7 @@ public class ProductService {
      * @throws ApplicationException 주문 희망 상품의 수와 실제 재고 차감된 상품 수가 달라 주문 프로세스 종료
      * @throws DataIntegrityViolationException 재고 부족으로 차감하지 못하는 경우 발생하는 예외
      */
-    @Transactional(propagation = Propagation.REQUIRES_NEW) // 상품 갱신을 위해 획득하는 락 점유 기간 최소화를 위해 신규 트랜잭션에서 수행
+    @Transactional
     public void decreaseInventoryForOrder(List<Long> orderProductIdList) throws ApplicationException, DataIntegrityViolationException {
         // 장바구니에 담은 상품들의 식별자
         int ret = productRepository.decreaseInventoryForOrderByProductIds(orderProductIdList);
@@ -215,7 +215,7 @@ public class ProductService {
      * 주문 실패 시 차감된 재고를 롤백하기 위한 보상 트랜잭션
      * @param orderProductIdList 재고 롤백할 상품 식별자 리스트
      */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void increaseInventoryForOrder(List<Long> orderProductIdList) {
         productRepository.increaseInventoryForOrderByProductIds(orderProductIdList);
     }


### PR DESCRIPTION
… 트랜잭션 분할

## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

원인: MariaDB의 Repeatable Read 트랜잭션에서의 쓰기/락 작업에 대한 격리 레벨 강화로 인해 트랜잭션 시작 시 생성된 스냅샷과 수정 대상의 최신 레코드 버전이 서로 맞지 않으면 강제 롤백되는 규칙
- 상품 재고 차감 로직을 신규 트랜잭션에서 수행하도록 분리하여, 해당 상품의 '최신 버전'을 새 트랜잭션이 갱신하게 한 것이 원인
- 세부 원인: order_item은 product 테이블을 외래키로 가지고, db에서 order_item을 insert할 때 외래키 무결성 검증을 위해 연관관계를 맺은 대상 product 레코드에 대해 공유 락(S)을 잠시 획득한다. 이 시점이 문제 발생 지점이다.

해결: 현재는 별도의 문제가 없으니 주문 정보 생성 로직을 단일 트랜잭션에서 처리하도록 변경
- 정합성을 최대한 보장하기 위해 격하했던 트랜잭션 격리 레벨을 다시 Repeatable Read로 복구

## 관련 이슈
<!---- 해당 PR과 관련된 이슈 번호가 있다면 작성해주세요. -->
<!---- Resolves: #(Isuue Number) -->

## PR 유형
<!-- 어떤 변경 사항이 있나요? -->

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
