### PR TITLE
[FEAT] 동시 로그인 로직 변경

### DIFF
--- a/src/main/java/com/example/monghyang/MonghyangApplication.java
+++ b/src/main/java/com/example/monghyang/MonghyangApplication.java
@@ -4,11 +4,14 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 
+import java.util.TimeZone;
+
 @SpringBootApplication
 @EnableWebSecurity(debug=true)
 public class MonghyangApplication {
 
 	public static void main(String[] args) {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
 		SpringApplication.run(MonghyangApplication.class, args);
 	}
 

--- a/src/main/java/com/example/monghyang/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/monghyang/domain/auth/service/AuthService.java
@@ -91,11 +91,10 @@ public class AuthService {
 
         JwtClaimsDto jwtClaimsDto = jwtUtil.parseRefreshToken(refreshToken);
         Long userId = jwtClaimsDto.getUserId();
-        String deviceType = jwtClaimsDto.getDeviceType();
         String tid = jwtClaimsDto.getTid();
         String role = jwtClaimsDto.getRole();
 
-        if(!redisService.verifyRefreshTokenTid(userId, deviceType, tid)) {
+        if(!redisService.verifyRefreshTokenTid(userId, tid)) {
             // 동시접속 감지 기준: 해당 유저의 해당 디바이스 타입의 리프레시 토큰 tid와 요청에 담긴 RT의 tid가 동일하지 않은 경우
             throw new ApplicationException(ApplicationError.CONCURRENT_CONNECTION);
         }

--- a/src/main/java/com/example/monghyang/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/monghyang/domain/auth/service/AuthService.java
@@ -94,11 +94,6 @@ public class AuthService {
         String tid = jwtClaimsDto.getTid();
         String role = jwtClaimsDto.getRole();
 
-        if(!redisService.verifyRefreshTokenTid(userId, tid)) {
-            // 동시접속 감지 기준: 해당 유저의 해당 디바이스 타입의 리프레시 토큰 tid와 요청에 담긴 RT의 tid가 동일하지 않은 경우
-            throw new ApplicationException(ApplicationError.CONCURRENT_CONNECTION);
-        }
-
         // 세션 및 토큰 갱신
         sessionUtil.createNewAuthInfo(request, response, userId, role);
     }

--- a/src/main/java/com/example/monghyang/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/monghyang/domain/auth/service/AuthService.java
@@ -94,6 +94,9 @@ public class AuthService {
         String tid = jwtClaimsDto.getTid();
         String role = jwtClaimsDto.getRole();
 
+        // 갱신 전의 refresh token, session 제거
+        redisService.deleteRefreshTokenAndSession(userId, tid);
+
         // 세션 및 토큰 갱신
         sessionUtil.createNewAuthInfo(request, response, userId, role);
     }

--- a/src/main/java/com/example/monghyang/domain/redis/RedisService.java
+++ b/src/main/java/com/example/monghyang/domain/redis/RedisService.java
@@ -9,6 +9,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.session.FindByIndexNameSessionRepository;
+import org.springframework.session.Session;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
@@ -21,12 +23,15 @@ public class RedisService {
     private final Long refreshTokenExpiration; // Redis 요소 수명
     private final Long sessionExpiration;
     private final RedisTemplate<String, String> stringRedisTemplate; // access token tid 저장용 redis 템플릿
+    private final FindByIndexNameSessionRepository<? extends Session> sessionRepository;
     @Autowired
     public RedisService(RedisTemplate<String, String> stringRedisTemplate, @Value("${jwt.refresh-expiration}") Duration refreshTokenExpiration,
-                        @Value("${spring.session.timeout}") Duration sessionExpiration) {
+                        @Value("${spring.session.timeout}") Duration sessionExpiration,
+                        FindByIndexNameSessionRepository<? extends Session> sessionRepository) {
         this.stringRedisTemplate = stringRedisTemplate;
         this.refreshTokenExpiration = refreshTokenExpiration.toMillis();
         this.sessionExpiration = sessionExpiration.toMillis();
+        this.sessionRepository = sessionRepository;
     }
 
     private String createRefreshTokenKey(Long userId) {
@@ -48,12 +53,6 @@ public class RedisService {
             throw new ApplicationException(ApplicationError.TOKEN_EXPIRED);
         }
         return storedTid.equals(tid);
-    }
-
-    // 세션 제거
-    public void deleteSessionId(String sessionId) {
-        String key = "spring:session:sessions:" + sessionId;
-        stringRedisTemplate.delete(key);
     }
 
     // 리프레시 토큰 제거

--- a/src/main/java/com/example/monghyang/domain/redis/RedisService.java
+++ b/src/main/java/com/example/monghyang/domain/redis/RedisService.java
@@ -21,16 +21,13 @@ import java.util.concurrent.TimeUnit;
 @Service
 public class RedisService {
     private final Long refreshTokenExpiration; // Redis 요소 수명
-    private final Long sessionExpiration;
     private final RedisTemplate<String, String> stringRedisTemplate; // access token tid 저장용 redis 템플릿
     private final FindByIndexNameSessionRepository<? extends Session> sessionRepository;
     @Autowired
     public RedisService(RedisTemplate<String, String> stringRedisTemplate, @Value("${jwt.refresh-expiration}") Duration refreshTokenExpiration,
-                        @Value("${spring.session.timeout}") Duration sessionExpiration,
                         FindByIndexNameSessionRepository<? extends Session> sessionRepository) {
         this.stringRedisTemplate = stringRedisTemplate;
         this.refreshTokenExpiration = refreshTokenExpiration.toMillis();
-        this.sessionExpiration = sessionExpiration.toMillis();
         this.sessionRepository = sessionRepository;
     }
 
@@ -45,7 +42,13 @@ public class RedisService {
     }
 
     // 리프레시 토큰 및 세션 제거
-    public void deleteRefreshTokenTid(Long userId, String tid) {
+
+    /**
+     * Refresh Token을 이용하여 Refresh Token, Session 제거
+     * @param userId 회원 식별자
+     * @param tid 토큰의 식별자
+     */
+    public void deleteRefreshTokenAndSession(Long userId, String tid) {
         String key = createRefreshTokenKey(userId, tid);
         String storedSid = stringRedisTemplate.opsForValue().get(key);
         if(storedSid != null){
@@ -54,6 +57,10 @@ public class RedisService {
         stringRedisTemplate.delete(key);
     }
 
+    /**
+     * 세션 정보 제거
+     * @param sessionId 세션 식별자(SID)
+     */
     public void deleteSession(String sessionId) {
         if(sessionId == null || sessionId.isBlank()) {
             return;
@@ -61,7 +68,7 @@ public class RedisService {
         try {
             sessionRepository.deleteById(sessionId);
         } catch (Exception e) {
-            log.warn("세션 삭제 중 예외 발생. sessinoId={}", sessionId, e);
+            log.warn("세션 삭제 중 예외 발생. sessionId={}", sessionId, e);
         }
     }
 
@@ -71,13 +78,36 @@ public class RedisService {
      */
     public void deleteAllInfoByUserId(Long userId) {
         String refreshKeyPattern = "refresh:"+userId+":*";
-        try(Cursor<String> cursor = stringRedisTemplate.scan(ScanOptions.scanOptions().match(refreshKeyPattern).count(5).build())) {
+        try(Cursor<String> cursor = stringRedisTemplate.scan(ScanOptions.scanOptions().match(refreshKeyPattern).count(10).build())) {
             while (cursor.hasNext()) {
                 String curRefreshKey = cursor.next();
                 String curSessionId = stringRedisTemplate.opsForValue().get(curRefreshKey);
                 stringRedisTemplate.delete(curRefreshKey);
                 deleteSession(curSessionId);
             }
+        } catch (Exception e) {
+            log.warn("특정 유저의 모든 인증 정보 및 Refresh Token 삭제 중 오류 발생. userId={}", userId, e);
+        }
+    }
+
+    /**
+     * 회원 식별자와 SID 조합에 해당되는 Refresh Token 제거
+     * @param userId 회원 식별자
+     * @param sessionId 세션 식별자
+     */
+    public void deleteRefreshTokenByUserIdAndSid(Long userId, String sessionId) {
+        String refreshKeyPattern = "refresh:"+userId+":*";
+        try(Cursor<String> cursor = stringRedisTemplate.scan(ScanOptions.scanOptions().match(refreshKeyPattern).count(10).build())) {
+            while (cursor.hasNext()) {
+                String curRefreshKey = cursor.next();
+                String curSessionId = stringRedisTemplate.opsForValue().get(curRefreshKey);
+                if(curSessionId.equals(sessionId)) {
+                    stringRedisTemplate.delete(curRefreshKey);
+                    break;
+                }
+            }
+        } catch (Exception e) {
+            log.error("인증 정보 수 조정을 위한 Refresh token 삭제 중 오류 발생. userId={}", userId, e);
         }
     }
 

--- a/src/main/java/com/example/monghyang/domain/redis/RedisService.java
+++ b/src/main/java/com/example/monghyang/domain/redis/RedisService.java
@@ -111,4 +111,14 @@ public class RedisService {
         }
     }
 
+    /**
+     * refresh token 존재 여부 검사
+     * @param userId 회원 식별자
+     * @param tid 토큰 식별자
+     * @return 존재하면 true 반환
+     */
+    public boolean isExistRefreshToken(Long userId, String tid) {
+        String key = createRefreshTokenKey(userId, tid);
+        return stringRedisTemplate.hasKey(key);
+    }
 }

--- a/src/main/java/com/example/monghyang/domain/redis/RedisService.java
+++ b/src/main/java/com/example/monghyang/domain/redis/RedisService.java
@@ -33,28 +33,11 @@ public class RedisService {
         return "refresh:"+userId;
     }
 
-    private String createLoginInfoKey(Long userId) {
-        return "auth:"+userId;
-    }
-
-    // 로그인 세션 리스트 정보 저장
-    public void setLoginInfoWithDeviceType(Long userId, String sessionId) {
-        String key = createLoginInfoKey(userId);
-        stringRedisTemplate.opsForValue().set(key, sessionId, sessionExpiration, TimeUnit.MILLISECONDS);
-    }
-
     // 세션 리프레시 토큰 정보 저장
     public void setRefreshTokenTid(Long userId, String tid) {
         String key = createRefreshTokenKey(userId);
         stringRedisTemplate.opsForValue().set(key, tid, refreshTokenExpiration, TimeUnit.MILLISECONDS);
     }
-
-    // 회원 식별자, 디바이스 타입에 해당하는 기존 키의 value(sid)를 반환
-    public String getSessionIdWithUserIdAndDeviceType(Long userId) {
-        String key = createLoginInfoKey(userId);
-        return stringRedisTemplate.opsForValue().get(key);
-    }
-
 
     // 유저의 refresh token tid 일치 여부 비교
     public boolean verifyRefreshTokenTid(Long userId, String tid) {
@@ -66,13 +49,6 @@ public class RedisService {
         }
         return storedTid.equals(tid);
     }
-
-    // 로그인 정보 ttl 갱신
-    public void extendLoginInfoTtl(Long userId) {
-        String key = createLoginInfoKey(userId);
-        stringRedisTemplate.expire(key, sessionExpiration, TimeUnit.MILLISECONDS);
-    }
-
 
     // 세션 제거
     public void deleteSessionId(String sessionId) {
@@ -86,19 +62,11 @@ public class RedisService {
         stringRedisTemplate.delete(key);
     }
 
-    // 디바이스별 로그인 정보 제거
-    public void deleteLoginInfo(Long userId) {
-        String key = createLoginInfoKey(userId);
-        String sessionId = getSessionIdWithUserIdAndDeviceType(userId);
-        deleteSessionId(sessionId);
-        stringRedisTemplate.delete(key);
-    }
-
     public void deleteAllInfo(Long userId) {
         int maxInfoNum = DeviceTypeUtil.DeviceType.values().length; // 한 유저가 가질 수 있는 최대 로그인 상태의 개수
 
         // 해당 유저의 모든 세션 제거
-        String loginInfoKeyPattern = "auth:"+userId+":*";
+        String loginInfoKeyPattern = "auth:"+userId;
         try(Cursor<String> cursor = stringRedisTemplate.scan(ScanOptions.scanOptions().match(loginInfoKeyPattern).count(maxInfoNum).build())) {
             while (cursor.hasNext()) {
                 String curLoginInfoKey = cursor.next();

--- a/src/main/java/com/example/monghyang/domain/redis/RedisService.java
+++ b/src/main/java/com/example/monghyang/domain/redis/RedisService.java
@@ -34,58 +34,51 @@ public class RedisService {
         this.sessionRepository = sessionRepository;
     }
 
-    private String createRefreshTokenKey(Long userId) {
-        return "refresh:"+userId;
+    private String createRefreshTokenKey(Long userId, String tid) {
+        return "refresh:"+userId+":"+tid;
     }
 
     // 세션 리프레시 토큰 정보 저장
-    public void setRefreshTokenTid(Long userId, String tid) {
-        String key = createRefreshTokenKey(userId);
-        stringRedisTemplate.opsForValue().set(key, tid, refreshTokenExpiration, TimeUnit.MILLISECONDS);
+    public void setRefreshTokenTid(Long userId, String tid, String sessionId) {
+        String key = createRefreshTokenKey(userId, tid);
+        stringRedisTemplate.opsForValue().set(key, sessionId, refreshTokenExpiration, TimeUnit.MILLISECONDS);
     }
 
-    // 유저의 refresh token tid 일치 여부 비교
-    public boolean verifyRefreshTokenTid(Long userId, String tid) {
-        String key = createRefreshTokenKey(userId);
-        String storedTid = stringRedisTemplate.opsForValue().get(key);
-        if(storedTid == null){
-            // 조회되는 것이 아무것도 없다면 토큰이 만료된 것 -> 재로그인 필요
-            throw new ApplicationException(ApplicationError.TOKEN_EXPIRED);
+    // 리프레시 토큰 및 세션 제거
+    public void deleteRefreshTokenTid(Long userId, String tid) {
+        String key = createRefreshTokenKey(userId, tid);
+        String storedSid = stringRedisTemplate.opsForValue().get(key);
+        if(storedSid != null){
+            deleteSession(storedSid);
         }
-        return storedTid.equals(tid);
-    }
-
-    // 리프레시 토큰 제거
-    public void deleteRefreshTokenTid(Long userId) {
-        String key = createRefreshTokenKey(userId);
         stringRedisTemplate.delete(key);
     }
 
-    public void deleteAllInfo(Long userId) {
-        int maxInfoNum = DeviceTypeUtil.DeviceType.values().length; // 한 유저가 가질 수 있는 최대 로그인 상태의 개수
+    public void deleteSession(String sessionId) {
+        if(sessionId == null || sessionId.isBlank()) {
+            return;
+        }
+        try {
+            sessionRepository.deleteById(sessionId);
+        } catch (Exception e) {
+            log.warn("세션 삭제 중 예외 발생. sessinoId={}", sessionId, e);
+        }
+    }
 
-        // 해당 유저의 모든 세션 제거
-        String loginInfoKeyPattern = "auth:"+userId;
-        try(Cursor<String> cursor = stringRedisTemplate.scan(ScanOptions.scanOptions().match(loginInfoKeyPattern).count(maxInfoNum).build())) {
+    /**
+     * redis에서 특정 유저의 모든 세션 및 refresh token 정보 제거
+     * @param userId 회원 식별자
+     */
+    public void deleteAllInfoByUserId(Long userId) {
+        String refreshKeyPattern = "refresh:"+userId+":*";
+        try(Cursor<String> cursor = stringRedisTemplate.scan(ScanOptions.scanOptions().match(refreshKeyPattern).count(5).build())) {
             while (cursor.hasNext()) {
-                String curLoginInfoKey = cursor.next();
-                String curSessionId = "spring:session:sessions:" + stringRedisTemplate.opsForValue().get(curLoginInfoKey);
-                stringRedisTemplate.delete(curSessionId);
-                stringRedisTemplate.delete(curLoginInfoKey);
+                String curRefreshKey = cursor.next();
+                String curSessionId = stringRedisTemplate.opsForValue().get(curRefreshKey);
+                stringRedisTemplate.delete(curRefreshKey);
+                deleteSession(curSessionId);
             }
         }
-
-        // 해당 유저의 모든 RT 제거
-        String refreshTokenKeyPattern = "refresh:"+userId+":*";
-        try(Cursor<String> cursor = stringRedisTemplate.scan(ScanOptions.scanOptions().match(refreshTokenKeyPattern).count(maxInfoNum).build())) {
-            while (cursor.hasNext()) {
-                String curRefreshTokenKey = cursor.next();
-                if(curRefreshTokenKey != null){
-                    stringRedisTemplate.delete(curRefreshTokenKey);
-                }
-            }
-        }
-
     }
 
 }

--- a/src/main/java/com/example/monghyang/domain/redis/RedisService.java
+++ b/src/main/java/com/example/monghyang/domain/redis/RedisService.java
@@ -29,36 +29,36 @@ public class RedisService {
         this.sessionExpiration = sessionExpiration.toMillis();
     }
 
-    private String createRefreshTokenKey(Long userId, String deviceType) {
-        return "refresh:"+userId+":"+deviceType;
+    private String createRefreshTokenKey(Long userId) {
+        return "refresh:"+userId;
     }
 
-    private String createLoginInfoKey(Long userId, String deviceType) {
-        return "auth:"+userId+":"+deviceType;
+    private String createLoginInfoKey(Long userId) {
+        return "auth:"+userId;
     }
 
     // 로그인 세션 리스트 정보 저장
-    public void setLoginInfoWithDeviceType(Long userId, String deviceType, String sessionId) {
-        String key = createLoginInfoKey(userId, deviceType);
+    public void setLoginInfoWithDeviceType(Long userId, String sessionId) {
+        String key = createLoginInfoKey(userId);
         stringRedisTemplate.opsForValue().set(key, sessionId, sessionExpiration, TimeUnit.MILLISECONDS);
     }
 
     // 세션 리프레시 토큰 정보 저장
-    public void setRefreshTokenTid(Long userId, String deviceType, String tid) {
-        String key = createRefreshTokenKey(userId, deviceType);
+    public void setRefreshTokenTid(Long userId, String tid) {
+        String key = createRefreshTokenKey(userId);
         stringRedisTemplate.opsForValue().set(key, tid, refreshTokenExpiration, TimeUnit.MILLISECONDS);
     }
 
     // 회원 식별자, 디바이스 타입에 해당하는 기존 키의 value(sid)를 반환
-    public String getSessionIdWithUserIdAndDeviceType(Long userId, String deviceType) {
-        String key = createLoginInfoKey(userId, deviceType);
+    public String getSessionIdWithUserIdAndDeviceType(Long userId) {
+        String key = createLoginInfoKey(userId);
         return stringRedisTemplate.opsForValue().get(key);
     }
 
 
     // 유저의 refresh token tid 일치 여부 비교
-    public boolean verifyRefreshTokenTid(Long userId, String deviceType, String tid) {
-        String key = createRefreshTokenKey(userId, deviceType);
+    public boolean verifyRefreshTokenTid(Long userId, String tid) {
+        String key = createRefreshTokenKey(userId);
         String storedTid = stringRedisTemplate.opsForValue().get(key);
         if(storedTid == null){
             // 조회되는 것이 아무것도 없다면 토큰이 만료된 것 -> 재로그인 필요
@@ -68,8 +68,8 @@ public class RedisService {
     }
 
     // 로그인 정보 ttl 갱신
-    public void expireLoginInfo(Long userId, String deviceType) {
-        String key = createLoginInfoKey(userId, deviceType);
+    public void extendLoginInfoTtl(Long userId) {
+        String key = createLoginInfoKey(userId);
         stringRedisTemplate.expire(key, sessionExpiration, TimeUnit.MILLISECONDS);
     }
 
@@ -81,15 +81,15 @@ public class RedisService {
     }
 
     // 리프레시 토큰 제거
-    public void deleteRefreshTokenTid(Long userId, String deviceType) {
-        String key = createRefreshTokenKey(userId, deviceType);
+    public void deleteRefreshTokenTid(Long userId) {
+        String key = createRefreshTokenKey(userId);
         stringRedisTemplate.delete(key);
     }
 
     // 디바이스별 로그인 정보 제거
-    public void deleteLoginInfo(Long userId, String deviceType) {
-        String key = createLoginInfoKey(userId, deviceType);
-        String sessionId = getSessionIdWithUserIdAndDeviceType(userId, deviceType);
+    public void deleteLoginInfo(Long userId) {
+        String key = createLoginInfoKey(userId);
+        String sessionId = getSessionIdWithUserIdAndDeviceType(userId);
         deleteSessionId(sessionId);
         stringRedisTemplate.delete(key);
     }

--- a/src/main/java/com/example/monghyang/domain/security/authHandler/CustomLogoutHandler.java
+++ b/src/main/java/com/example/monghyang/domain/security/authHandler/CustomLogoutHandler.java
@@ -41,7 +41,7 @@ public class CustomLogoutHandler implements LogoutHandler {
             userId = jwtClaimsDto.getUserId();
 
             if(userId != null) {
-                redisService.deleteRefreshTokenTid(userId, tid); // 리프레시 토큰 삭제
+                redisService.deleteRefreshTokenAndSession(userId, tid); // 리프레시 토큰 삭제
             }
         } catch (ApplicationException e) {
             log.error("토큰 관련 예외 발생. user id: {}, device type: {}\nerror message: {}", userId, e.getMessage());

--- a/src/main/java/com/example/monghyang/domain/security/authHandler/CustomLogoutHandler.java
+++ b/src/main/java/com/example/monghyang/domain/security/authHandler/CustomLogoutHandler.java
@@ -34,27 +34,25 @@ public class CustomLogoutHandler implements LogoutHandler {
 
         String tid = "";
         Long userId = -1L;
-        String deviceType = "";
 
         try {
             JwtClaimsDto jwtClaimsDto = jwtUtil.parseRefreshToken(refreshToken);
             tid = jwtClaimsDto.getTid();
             userId = jwtClaimsDto.getUserId();
-            deviceType = jwtClaimsDto.getDeviceType();
 
-            if(!redisService.verifyRefreshTokenTid(userId, deviceType, tid)) {
+            if(!redisService.verifyRefreshTokenTid(userId, tid)) {
                 // redis에 존재하지 않는 RT를 이용하여 로그아웃을 시도하는 경우, 서버에서는 아무런 조치를 취하지 않는다.
                 return;
             }
 
             if(userId != null) {
-                redisService.deleteLoginInfo(userId, deviceType); // 디바이스 별 로그인 정보 삭제
-                redisService.deleteRefreshTokenTid(userId, deviceType); // 디바이스 별 리프레시 토큰 삭제
+                redisService.deleteLoginInfo(userId); // 디바이스 별 로그인 정보 삭제
+                redisService.deleteRefreshTokenTid(userId); // 디바이스 별 리프레시 토큰 삭제
             }
         } catch (ApplicationException e) {
-            log.error("토큰 관련 예외 발생. user id: {}, device type: {}\nerror message: {}", userId, deviceType, e.getMessage());
+            log.error("토큰 관련 예외 발생. user id: {}, device type: {}\nerror message: {}", userId, e.getMessage());
         } catch (Exception e) {
-            log.error("로그아웃 redis 접근 중 에러 발생. user id: {}, device type: {}\nerror message: {}", userId, deviceType, e.getMessage());
+            log.error("로그아웃 redis 접근 중 에러 발생. user id: {}, device type: {}\nerror message: {}", userId, e.getMessage());
         }
     }
 }

--- a/src/main/java/com/example/monghyang/domain/security/authHandler/CustomLogoutHandler.java
+++ b/src/main/java/com/example/monghyang/domain/security/authHandler/CustomLogoutHandler.java
@@ -40,14 +40,8 @@ public class CustomLogoutHandler implements LogoutHandler {
             tid = jwtClaimsDto.getTid();
             userId = jwtClaimsDto.getUserId();
 
-            if(!redisService.verifyRefreshTokenTid(userId, tid)) {
-                // redis에 존재하지 않는 RT를 이용하여 로그아웃을 시도하는 경우, 서버에서는 아무런 조치를 취하지 않는다.
-                return;
-            }
-
             if(userId != null) {
-                redisService.deleteLoginInfo(userId); // 디바이스 별 로그인 정보 삭제
-                redisService.deleteRefreshTokenTid(userId); // 디바이스 별 리프레시 토큰 삭제
+                redisService.deleteRefreshTokenTid(userId, tid); // 리프레시 토큰 삭제
             }
         } catch (ApplicationException e) {
             log.error("토큰 관련 예외 발생. user id: {}, device type: {}\nerror message: {}", userId, e.getMessage());

--- a/src/main/java/com/example/monghyang/domain/security/authHandler/CustomSecurityContextRepository.java
+++ b/src/main/java/com/example/monghyang/domain/security/authHandler/CustomSecurityContextRepository.java
@@ -54,10 +54,9 @@ public class CustomSecurityContextRepository implements SecurityContextRepositor
             Object sessionUserInfo = session.getAttribute(SESSION_USER_INFO_NAME);
             if(sessionUserInfo instanceof SessionUserInfo(Long userId, String role)) {
                 // 세션에 저장된 SessionUserInfo 객체 파싱
-                String deviceType = DeviceTypeUtil.getDeviceType(request).name();
                 List<GrantedAuthority> authentication = Collections.singletonList(new SimpleGrantedAuthority(role));
 
-                redisService.expireLoginInfo(userId, deviceType); // redis의 로그인 정보 ttl 또한 갱신
+                redisService.extendLoginInfoTtl(userId); // redis의 로그인 정보 ttl 또한 갱신
 
                 // 인증 정보 생성 및 세팅
                 Authentication auth = new UsernamePasswordAuthenticationToken(userId, null, authentication);

--- a/src/main/java/com/example/monghyang/domain/security/authHandler/CustomSecurityContextRepository.java
+++ b/src/main/java/com/example/monghyang/domain/security/authHandler/CustomSecurityContextRepository.java
@@ -56,8 +56,6 @@ public class CustomSecurityContextRepository implements SecurityContextRepositor
                 // 세션에 저장된 SessionUserInfo 객체 파싱
                 List<GrantedAuthority> authentication = Collections.singletonList(new SimpleGrantedAuthority(role));
 
-                redisService.extendLoginInfoTtl(userId); // redis의 로그인 정보 ttl 또한 갱신
-
                 // 인증 정보 생성 및 세팅
                 Authentication auth = new UsernamePasswordAuthenticationToken(userId, null, authentication);
                 context.setAuthentication(auth);

--- a/src/main/java/com/example/monghyang/domain/security/authHandler/CustomSecurityContextRepository.java
+++ b/src/main/java/com/example/monghyang/domain/security/authHandler/CustomSecurityContextRepository.java
@@ -30,7 +30,6 @@ public class CustomSecurityContextRepository implements SecurityContextRepositor
 
     private static final String SESSION_HEADER_NAME = "X-Session-Id";
     private static final String SESSION_USER_INFO_NAME = "sessionUserInfo";
-    private final RedisService redisService;
 
 
     // IDE의 컴파일 에러를 해결하기 위한 임시방편 코드입니다.
@@ -48,6 +47,7 @@ public class CustomSecurityContextRepository implements SecurityContextRepositor
             HttpSession session = request.getSession(false); // 세션 저장소에서 SID로 세션 조회
             if(session == null) {
                 // 조회 결과 없다면 '익명' 사용자
+                System.out.println("세션 정보가 존재하지 않습니다.");
                 return context;
             }
 

--- a/src/main/java/com/example/monghyang/domain/security/authHandler/SessionLogoutSuccessHandler.java
+++ b/src/main/java/com/example/monghyang/domain/security/authHandler/SessionLogoutSuccessHandler.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 
 @Component
 @RequiredArgsConstructor
-public class SessionLogoutSeccessHandler implements LogoutSuccessHandler {
+public class SessionLogoutSuccessHandler implements LogoutSuccessHandler {
     private final ObjectMapper objectMapper;
     @Override
     public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {

--- a/src/main/java/com/example/monghyang/domain/security/config/SecurityConfig.java
+++ b/src/main/java/com/example/monghyang/domain/security/config/SecurityConfig.java
@@ -70,7 +70,7 @@ public class SecurityConfig {
 
     @Bean
     @Order(2)
-    public SecurityFilterChain securityFilterChain(HttpSecurity http, CustomAuthenticationEntryPoint authenticationEntryPoint, CustomAccessDeniedHandler accessDeniedHandler, CustomOAuth2AuthenticationSuccessHandler customOAuth2AuthenticationSuccessHandler, CustomOAuth2AuthenticationFailureHandler customOAuth2AuthenticationFailureHandler, SessionLoginSuccessHandler sessionLoginSuccessHandler, SessionLoginFailureHandler sessionLoginFailureHandler, CustomLogoutHandler customLogoutHandler, SessionLogoutSeccessHandler sessionLogoutSeccessHandler, SecurityMdcFilter securityMdcFilter) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, CustomAuthenticationEntryPoint authenticationEntryPoint, CustomAccessDeniedHandler accessDeniedHandler, CustomOAuth2AuthenticationSuccessHandler customOAuth2AuthenticationSuccessHandler, CustomOAuth2AuthenticationFailureHandler customOAuth2AuthenticationFailureHandler, SessionLoginSuccessHandler sessionLoginSuccessHandler, SessionLoginFailureHandler sessionLoginFailureHandler, CustomLogoutHandler customLogoutHandler, SessionLogoutSuccessHandler sessionLogoutSeccessHandler, SecurityMdcFilter securityMdcFilter) throws Exception {
         // application api 요청에 대한 Security Filter Chain
         http
                 .csrf(AbstractHttpConfigurer::disable)

--- a/src/main/java/com/example/monghyang/domain/security/config/SecurityConfig.java
+++ b/src/main/java/com/example/monghyang/domain/security/config/SecurityConfig.java
@@ -148,8 +148,6 @@ public class SecurityConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
                         .sessionConcurrency(concurrency -> concurrency
-                                .maximumSessions(5)
-                                .maxSessionsPreventsLogin(false)
                                 .sessionRegistry(sessionRegistry())
                         )
                 );

--- a/src/main/java/com/example/monghyang/domain/security/config/SecurityConfig.java
+++ b/src/main/java/com/example/monghyang/domain/security/config/SecurityConfig.java
@@ -21,6 +21,9 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
+import org.springframework.session.FindByIndexNameSessionRepository;
+import org.springframework.session.Session;
+import org.springframework.session.security.SpringSessionBackedSessionRegistry;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 
@@ -32,16 +35,22 @@ public class SecurityConfig {
     private final List<String> clientUrl;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final CustomSecurityContextRepository customSecurityContextRepository;
+    private final FindByIndexNameSessionRepository<? extends Session> sessionRepository;
 
     @Autowired
-    public SecurityConfig(@Value("${app.client-url}") List<String> clientUrl, CustomOAuth2UserService customOAuth2UserService, CustomSecurityContextRepository customSecurityContextRepository) {
+    public SecurityConfig(@Value("${app.client-url}") List<String> clientUrl, CustomOAuth2UserService customOAuth2UserService, CustomSecurityContextRepository customSecurityContextRepository, FindByIndexNameSessionRepository<? extends Session> sessionRepository) {
         this.clientUrl = clientUrl;
         this.customOAuth2UserService = customOAuth2UserService;
         this.customSecurityContextRepository = customSecurityContextRepository;
+        this.sessionRepository = sessionRepository;
     }
 
     @Bean
     BCryptPasswordEncoder bCryptPasswordEncoder() { return new BCryptPasswordEncoder(); }
+    @Bean
+    public SpringSessionBackedSessionRegistry<? extends Session> sessionRegistry() {
+        return new SpringSessionBackedSessionRegistry<>(this.sessionRepository);
+    }
     @Bean
     SecurityContextLogoutHandler securityContextLogoutHandler() {
         return new SecurityContextLogoutHandler();
@@ -136,7 +145,14 @@ public class SecurityConfig {
                         .clearAuthentication(true)) // 현재 Security Context 비우기
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .addFilterAfter(securityMdcFilter, UsernamePasswordAuthenticationFilter.class)
-                .sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED));
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
+                        .sessionConcurrency(concurrency -> concurrency
+                                .maximumSessions(5)
+                                .maxSessionsPreventsLogin(false)
+                                .sessionRegistry(sessionRegistry())
+                        )
+                );
         return http.build();
     }
 }

--- a/src/main/java/com/example/monghyang/domain/users/controller/UsersController.java
+++ b/src/main/java/com/example/monghyang/domain/users/controller/UsersController.java
@@ -58,8 +58,6 @@ public class UsersController {
             @LoginUserId Long userId, @LoginUserRole String userRole,
             @Valid @ModelAttribute ReqUsersDto reqUsersDto,
             HttpServletRequest request, HttpServletResponse response) {
-        System.out.println("유저 식별자: "+userId+", 유저 권한: "+userRole);
-
         usersService.updateUsers(userId, reqUsersDto, userRole);
 
         // 해당 유저의 현재 세션 정보를 제거
@@ -67,8 +65,8 @@ public class UsersController {
         if(auth != null) {
             securityContextLogoutHandler.logout(request, response, auth);
         }
-        // 해당 유저의 나머지 모든 세션 정보 및 refresh token 정보를 제거
-        redisService.deleteAllInfo(userId);
+        // 해당 유저의 나머지 모든 세션 정보 제거
+        redisService.deleteAllInfoByUserId(userId);
 
         return ResponseEntity.ok().body(ResponseDataDto.success("회원 수정이 완료되었습니다. 다시 로그인 해주세요."));
     }
@@ -89,7 +87,7 @@ public class UsersController {
             securityContextLogoutHandler.logout(request, response, auth);
         }
         // 해당 유저의 나머지 모든 세션 정보 및 refresh token 정보를 제거
-        redisService.deleteAllInfo(userId);
+        redisService.deleteAllInfoByUserId(userId);
         return ResponseEntity.ok().body(ResponseDataDto.success("회원 탈퇴가 완료되었습니다."));
     }
 }

--- a/src/main/java/com/example/monghyang/domain/util/JwtUtil.java
+++ b/src/main/java/com/example/monghyang/domain/util/JwtUtil.java
@@ -61,9 +61,9 @@ public class JwtUtil {
     }
 
     // session refresh token 발급
-    public String createRefreshToken(Long userId, String role) {
+    public String createRefreshToken(Long userId, String role, String sessionId) {
         String refreshTokenId = UUID.randomUUID().toString();
-        redisService.setRefreshTokenTid(userId, refreshTokenId); // redis에 refresh token tid 저장
+        redisService.setRefreshTokenTid(userId, refreshTokenId, sessionId); // redis에 refresh token tid와 sid 저장
         return Jwts.builder()
                 .claim("userId", userId)
                 .claim("role", role)

--- a/src/main/java/com/example/monghyang/domain/util/JwtUtil.java
+++ b/src/main/java/com/example/monghyang/domain/util/JwtUtil.java
@@ -51,9 +51,8 @@ public class JwtUtil {
 
             String tid = claims.getId();
             Long userId = claims.get("userId", Long.class);
-            String deviceType = claims.get("deviceType", String.class);
             String role = claims.get("role", String.class);
-            return JwtClaimsDto.tidUserIdDeviceTypeRoleOf(tid, userId, deviceType, role);
+            return JwtClaimsDto.tidUserIdDeviceTypeRoleOf(tid, userId, role);
         } catch (JwtException | IllegalArgumentException e) {
             // 토큰 파싱 예외 처리
             log.error("토큰 훼손: {}", e.getMessage());
@@ -62,12 +61,11 @@ public class JwtUtil {
     }
 
     // session refresh token 발급
-    public String createRefreshToken(Long userId, String deviceType, String role) {
+    public String createRefreshToken(Long userId, String role) {
         String refreshTokenId = UUID.randomUUID().toString();
-        redisService.setRefreshTokenTid(userId, deviceType, refreshTokenId); // redis에 refresh token tid 저장
+        redisService.setRefreshTokenTid(userId, refreshTokenId); // redis에 refresh token tid 저장
         return Jwts.builder()
                 .claim("userId", userId)
-                .claim("deviceType", deviceType)
                 .claim("role", role)
                 .setId(refreshTokenId)
                 .setIssuedAt(new Date(System.currentTimeMillis()))

--- a/src/main/java/com/example/monghyang/domain/util/JwtUtil.java
+++ b/src/main/java/com/example/monghyang/domain/util/JwtUtil.java
@@ -44,14 +44,15 @@ public class JwtUtil {
                     .parseClaimsJws(token)
                     .getBody();
 
-            if(claims.getExpiration().before(new Date())) {
+            String tid = claims.getId();
+            Long userId = claims.get("userId", Long.class);
+            String role = claims.get("role", String.class);
+
+            if(!redisService.isExistRefreshToken(userId, tid) || claims.getExpiration().before(new Date())) {
                 // 토큰 만료 시 예외 발생
                 throw new ApplicationException(ApplicationError.TOKEN_EXPIRED);
             }
 
-            String tid = claims.getId();
-            Long userId = claims.get("userId", Long.class);
-            String role = claims.get("role", String.class);
             return JwtClaimsDto.tidUserIdDeviceTypeRoleOf(tid, userId, role);
         } catch (JwtException | IllegalArgumentException e) {
             // 토큰 파싱 예외 처리

--- a/src/main/java/com/example/monghyang/domain/util/SessionUtil.java
+++ b/src/main/java/com/example/monghyang/domain/util/SessionUtil.java
@@ -33,7 +33,7 @@ public class SessionUtil {
 
         // 동일 유저의 세션 정보 개수가 5개를 초과하면 가장 오래전에 생성된 세션 정보를 제거한다. (구현 예정)
 
-        String refreshToken = jwtUtil.createRefreshToken(userId, role); // redis에 refresh token 정보 저장
+        String refreshToken = jwtUtil.createRefreshToken(userId, role, session.getId()); // redis에 refresh token 정보 저장
         response.setHeader("X-Refresh-Token", refreshToken); // 응답 헤더에 refresh token 첨부
     }
 }

--- a/src/main/java/com/example/monghyang/domain/util/SessionUtil.java
+++ b/src/main/java/com/example/monghyang/domain/util/SessionUtil.java
@@ -9,16 +9,41 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.session.FindByIndexNameSessionRepository;
+import org.springframework.session.Session;
 import org.springframework.stereotype.Component;
+
+import java.util.Comparator;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
 public class SessionUtil {
-    private final RedisService redisService;
+    private static final int MAX_SESSIONS_PER_USER = 5;
+    private final FindByIndexNameSessionRepository<? extends Session> sessionRepository;
     private final JwtUtil jwtUtil;
+    private final RedisService redisService;
 
     // 새로운 세션 및 RT 생성
     public void createNewAuthInfo(HttpServletRequest request, HttpServletResponse response, Long userId, String role) {
+        String principal = userId.toString();
+        Map<String, ? extends Session> sessionsByPrincipal =
+                sessionRepository.findByIndexNameAndIndexValue(
+                        FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME,
+                        principal);
+        int currentSessionCount = sessionsByPrincipal.size();
+        if(currentSessionCount >= MAX_SESSIONS_PER_USER) {
+            int toDelete = currentSessionCount + 1 - MAX_SESSIONS_PER_USER;
+            sessionsByPrincipal.values().stream()
+                    .sorted(Comparator.comparing(Session::getCreationTime))
+                    .limit(toDelete)
+                    .forEach(session -> {
+                        redisService.deleteRefreshTokenByUserIdAndSid(userId, session.getId()); // refresh token 제거
+                        sessionRepository.deleteById(session.getId()); // 세션 제거
+                    });
+        }
+
+
         HttpSession session = request.getSession(true); // 기존에 존재하는 세션을 조회. 세션이 없다면 새로 생성(true)
         if(session == null) { // 세션이 생성되지 않은 경우 예외처리
             throw new ApplicationException(ApplicationError.SESSION_CREATE_ERROR);
@@ -31,7 +56,9 @@ public class SessionUtil {
         // 마지막 로그인 지역 정보 저장
         session.setAttribute("lastAccessLocation", request.getRemoteAddr());
 
-        // 동일 유저의 세션 정보 개수가 5개를 초과하면 가장 오래전에 생성된 세션 정보를 제거한다. (구현 예정)
+        // index key 설정
+        session.setAttribute(FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME,
+                userId.toString());
 
         String refreshToken = jwtUtil.createRefreshToken(userId, role, session.getId()); // redis에 refresh token 정보 저장
         response.setHeader("X-Refresh-Token", refreshToken); // 응답 헤더에 refresh token 첨부

--- a/src/main/java/com/example/monghyang/domain/util/SessionUtil.java
+++ b/src/main/java/com/example/monghyang/domain/util/SessionUtil.java
@@ -31,17 +31,15 @@ public class SessionUtil {
         // 마지막 로그인 지역 정보 저장
         session.setAttribute("lastAccessLocation", request.getRemoteAddr());
 
-        String deviceType = DeviceTypeUtil.getDeviceType(request).name(); // 로그인을 시도한 클라이언트의 디바이스 타입
-
         // 동일한 계정, 디바이스 타입의 로그인 정보가 이미 있는 경우, 기존 SID를 삭제하고 새로운 데이터로 덮어씌운다.(디바이스 별 세션 정보)
-        String storedSessionId = redisService.getSessionIdWithUserIdAndDeviceType(userId, deviceType);
+        String storedSessionId = redisService.getSessionIdWithUserIdAndDeviceType(userId);
         if(storedSessionId != null) {
             redisService.deleteSessionId(storedSessionId);
         }
 
-        redisService.setLoginInfoWithDeviceType(userId, deviceType, session.getId()); // redis에 사용자 로그인 세션 정보 리스트 저장
+        redisService.setLoginInfoWithDeviceType(userId, session.getId()); // redis에 사용자 로그인 세션 정보 리스트 저장
 
-        String refreshToken = jwtUtil.createRefreshToken(userId, deviceType, role); // redis에 refresh token 정보 저장
+        String refreshToken = jwtUtil.createRefreshToken(userId, role); // redis에 refresh token 정보 저장
         response.setHeader("X-Refresh-Token", refreshToken); // 응답 헤더에 refresh token 첨부
     }
 }

--- a/src/main/java/com/example/monghyang/domain/util/SessionUtil.java
+++ b/src/main/java/com/example/monghyang/domain/util/SessionUtil.java
@@ -31,13 +31,7 @@ public class SessionUtil {
         // 마지막 로그인 지역 정보 저장
         session.setAttribute("lastAccessLocation", request.getRemoteAddr());
 
-        // 동일한 계정, 디바이스 타입의 로그인 정보가 이미 있는 경우, 기존 SID를 삭제하고 새로운 데이터로 덮어씌운다.(디바이스 별 세션 정보)
-        String storedSessionId = redisService.getSessionIdWithUserIdAndDeviceType(userId);
-        if(storedSessionId != null) {
-            redisService.deleteSessionId(storedSessionId);
-        }
-
-        redisService.setLoginInfoWithDeviceType(userId, session.getId()); // redis에 사용자 로그인 세션 정보 리스트 저장
+        // 동일 유저의 세션 정보 개수가 5개를 초과하면 가장 오래전에 생성된 세션 정보를 제거한다. (구현 예정)
 
         String refreshToken = jwtUtil.createRefreshToken(userId, role); // redis에 refresh token 정보 저장
         response.setHeader("X-Refresh-Token", refreshToken); // 응답 헤더에 refresh token 첨부

--- a/src/main/java/com/example/monghyang/domain/util/dto/JwtClaimsDto.java
+++ b/src/main/java/com/example/monghyang/domain/util/dto/JwtClaimsDto.java
@@ -8,17 +8,15 @@ import lombok.Setter;
 public class JwtClaimsDto {
     private String tid;
     private Long userId;
-    private String deviceType;
     private String role;
 
-    private JwtClaimsDto(String tid, Long userId, String deviceType, String role) {
+    private JwtClaimsDto(String tid, Long userId, String role) {
         this.tid = tid;
         this.userId = userId;
-        this.deviceType = deviceType;
         this.role = role;
     }
 
-    public static JwtClaimsDto tidUserIdDeviceTypeRoleOf(String tid, Long userId, String deviceType, String role) {
-        return new JwtClaimsDto(tid, userId, deviceType, role);
+    public static JwtClaimsDto tidUserIdDeviceTypeRoleOf(String tid, Long userId, String role) {
+        return new JwtClaimsDto(tid, userId, role);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,7 @@ spring:
       namespace: spring:session
       flush-mode: on_save
       save-mode: on_set_attribute
+      repository-type: indexed # 유저 당 최대 세션 개수 제한을 위해 indexed 방식 활용
   jackson:
     mapper:
       accept-case-insensitive-enums: true # enum 대소문자 구분없이 매핑

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,8 @@ spring:
       max-request-size: 50MB
   jpa:
     properties:
-      hibernate.jdbc.time_zone: Asia/Seoul
+      hibernate:
+        jdbc.time_zone: Asia/Seoul
   security:
     oauth2:
       client:

--- a/src/main/resources/docker-compose.yml
+++ b/src/main/resources/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: redis:8.0.3-alpine
     container_name: redis
     restart: unless-stopped
+    mem_limit: 500m             # redis 컨테이너에 할당되는 메모리: 500mb
     command:
       - "redis-server"
       - "--save"
@@ -11,6 +12,10 @@ services:
       - "100"
       - "--requirepass"
       - "${REDIS_PASSWORD}"
+      - "--maxmemory"
+      - "480mb"                 # redis의 메모리 상한선: 480mb (500mb가 되면 프로세스가 kill된다)
+      - "--maxmemory-policy"    # 메모리 관리 정책 설정
+      - "volatile-lru"          # 메모리 관리 정책: LRU
     ports:
       - "6379:6379"                        # 호스트 접속용 (원격 노출 불필요하면 제거)
     volumes:

--- a/src/test/java/com/example/monghyang/devtest/AuthServiceTest.java
+++ b/src/test/java/com/example/monghyang/devtest/AuthServiceTest.java
@@ -647,8 +647,6 @@ public class AuthServiceTest {
         String tid = jwtDto.getTid();
         String role = jwtDto.getRole();
         given(jwtUtil.parseRefreshToken(token)).willReturn(jwtDto);
-        given(redisService.verifyRefreshTokenTid(userId, tid))
-                .willReturn(true);
         authService.updateRefreshToken(request, response);
     }
 
@@ -675,8 +673,6 @@ public class AuthServiceTest {
         String tid = jwtDto.getTid();
         String role = jwtDto.getRole();
         given(jwtUtil.parseRefreshToken(token)).willReturn(jwtDto);
-        given(redisService.verifyRefreshTokenTid(userId, tid))
-                .willReturn(false);
         ApplicationException ex = assertThrows(ApplicationException.class, () -> authService.updateRefreshToken(request, response));
         assertEquals(ex.getApplicationError(), ApplicationError.CONCURRENT_CONNECTION);
     }

--- a/src/test/java/com/example/monghyang/devtest/AuthServiceTest.java
+++ b/src/test/java/com/example/monghyang/devtest/AuthServiceTest.java
@@ -642,13 +642,12 @@ public class AuthServiceTest {
         String token = "refreshToken";
         given(request.getHeader("X-Refresh-Token"))
                 .willReturn(token);
-        JwtClaimsDto jwtDto = JwtClaimsDto.tidUserIdDeviceTypeRoleOf("t1234", 1L, "desktop", "ROLE_UESR");
+        JwtClaimsDto jwtDto = JwtClaimsDto.tidUserIdDeviceTypeRoleOf("t1234", 1L, "ROLE_UESR");
         Long userId = jwtDto.getUserId();
-        String deviceType = jwtDto.getDeviceType();
         String tid = jwtDto.getTid();
         String role = jwtDto.getRole();
         given(jwtUtil.parseRefreshToken(token)).willReturn(jwtDto);
-        given(redisService.verifyRefreshTokenTid(userId, deviceType, tid))
+        given(redisService.verifyRefreshTokenTid(userId, tid))
                 .willReturn(true);
         authService.updateRefreshToken(request, response);
     }
@@ -671,13 +670,12 @@ public class AuthServiceTest {
         String token = "refreshToken";
         given(request.getHeader("X-Refresh-Token"))
                 .willReturn(token);
-        JwtClaimsDto jwtDto = JwtClaimsDto.tidUserIdDeviceTypeRoleOf("t1234", 1L, "desktop", "ROLE_UESR");
+        JwtClaimsDto jwtDto = JwtClaimsDto.tidUserIdDeviceTypeRoleOf("t1234", 1L, "ROLE_UESR");
         Long userId = jwtDto.getUserId();
-        String deviceType = jwtDto.getDeviceType();
         String tid = jwtDto.getTid();
         String role = jwtDto.getRole();
         given(jwtUtil.parseRefreshToken(token)).willReturn(jwtDto);
-        given(redisService.verifyRefreshTokenTid(userId, deviceType, tid))
+        given(redisService.verifyRefreshTokenTid(userId, tid))
                 .willReturn(false);
         ApplicationException ex = assertThrows(ApplicationException.class, () -> authService.updateRefreshToken(request, response));
         assertEquals(ex.getApplicationError(), ApplicationError.CONCURRENT_CONNECTION);


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

1. 로그인 식별 정보에서 '디바이스 타입' 정보 제거
2. 동일 유저의 최대 동시 로그인 허용 수 5개로 제한, 초과 시 가장 예전에 생성된 세션 및 토큰 정보 파기하여 개수 유지
3. 동시 로그인 수 제어를 위해 Redis Session 저장 방식을 Indexed로 변경
4. Redis Session 할당 메모리 **500MB**로 변경
    a. 동시 접속 5개 유지 중인 유저 기준, 최대 약 60,000명의 동시 접속 허용
    b. 메모리 관리 정책: LRU

## 관련 이슈
<!---- 해당 PR과 관련된 이슈 번호가 있다면 작성해주세요. -->
<!---- Resolves: #66  -->

## PR 유형
<!-- 어떤 변경 사항이 있나요? -->

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
